### PR TITLE
feat: Prevent double-click propagation on description toggle button

### DIFF
--- a/src/views/TaskComponent.svelte
+++ b/src/views/TaskComponent.svelte
@@ -53,6 +53,10 @@
 
     isExpanded = !isExpanded;
   }
+
+  function stopDoubleClickPropagation(event: MouseEvent) {
+    event.stopPropagation();
+  }
 </script>
 
 <style>
@@ -157,6 +161,7 @@
               bind:this={descriptionIon}
               style:display={!!task.description ? null : "none"}
               onclick={onClickDescription}
+              ondblclick={stopDoubleClickPropagation}
               tabindex="0"
               aria-label={isExpanded ? t("view.aria-lbl-collapse-description") : t("view.aria-lbl-expand-description")}
               aria-expanded={isExpanded}></button>


### PR DESCRIPTION
This issue was introduced as #9 was added. This PR resolves the issue that a double click on "expand button" opens the edit window. Users have to double click on the row/title of the task.
The edit-dialog should not open, when expand/collapse is clicked too quickly.